### PR TITLE
Add json output formatter

### DIFF
--- a/netperf_wrapper/formatters.py
+++ b/netperf_wrapper/formatters.py
@@ -202,6 +202,24 @@ class CsvFormatter(TableFormatter):
         for row in self.combine_results(results):
             writer.writerow(list(map(format_item, row)))
 
+
+class JsonFormatter(Formatter):
+    """Format the output as json."""
+
+    def format(self, results):
+        self.open_output()
+
+        data = []
+        for result in results:
+            d = result.serialise()
+            for s in sorted(result.series_names):
+                units = self.settings.DATA_SETS[s]['units']
+                d['metadata']['SERIES_META'][s]['UNITS'] = units
+            data.append(d)
+
+        self.output.write(json.dumps(data))
+
+
 class StatsFormatter(Formatter):
 
     def __init__(self, settings):

--- a/netperf_wrapper/settings.py
+++ b/netperf_wrapper/settings.py
@@ -211,7 +211,7 @@ parser.add_option("-i", "--input", action="append", type="string", dest="INPUT",
                   help="File to read input from (instead of running tests). Input files "
                   "can also be specified as unqualified arguments without using the -i switch.")
 parser.add_option("-f", "--format", action="store", type="string", dest="FORMAT",
-                  help="Select output format (plot, csv, org_table, stats, metadata). Default is "
+                  help="Select output format (plot, csv, org_table, stats, metadata, json). Default is "
                   "no processed output (just writes the JSON data file).")
 parser.add_option("-p", "--plot", action="store", type="string", dest="PLOT",
                   help="Select which plot to output for the given test (implies -f plot). "


### PR DESCRIPTION
The patch extends output parameter with option "json". With it netperf-wrapper prints raw json data to stdout.